### PR TITLE
Add copy button to copy bin url code

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -48,13 +48,20 @@
 	padding-right: 10px;
 }
 
-.inspect-link {
+.inspect-link, .inspect-copy {
 	cursor: pointer;
 }
 
 .inspect-link:hover {
 	padding-right: -10px;
 	transition: margin 250;
+}
+.inspect-copy:hover {
+    margin-top: -10px;
+}
+
+.inspect-copy:active {
+    margin-top: -5px;
 }
 
 .private {

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
 </head>
 <body>
 	<div class="inspect-container" style="display: none;">
+		<span class="inspect-copy" title="copy to clipboard">&#128203;</span>
 		<span class="inspect-code"></span>
 		<span class="inspect-link">&#10148;</span>
 	</div>

--- a/js/app.js
+++ b/js/app.js
@@ -15,12 +15,12 @@ function createBin() {
         'data': {'private': $('.private').prop("checked")},
 
         'success': function(data) {
-            console.log(chrome);
             $('.get-container').slideUp();
 
             var binUrl = "http://requestb.in/" + data.name;
-            copyToClipboard(binUrl);
 
+
+            $('.inspect-copy').click(function() { copyToClipboard(binUrl); });
             $('.inspect-code').text(data.name);
             $('.inspect-link').click(function() { window.open(binUrl + "?inspect"); });
             $('.inspect-container').slideDown();

--- a/js/app.js
+++ b/js/app.js
@@ -1,5 +1,13 @@
 chrome.browserAction.setIcon({'path': 'logo-2x.png'});
 
+function copyToClipboard(text) {
+    var $temp = $("<input>");
+    $("body").append($temp);
+    $temp.val(text).select();
+    document.execCommand("copy");
+    $temp.remove();
+}
+
 function createBin() {
     $('.get-link').text('Creating new bin...');
 
@@ -10,8 +18,11 @@ function createBin() {
             console.log(chrome);
             $('.get-container').slideUp();
 
+            var binUrl = "http://requestb.in/" + data.name;
+            copyToClipboard(binUrl);
+
             $('.inspect-code').text(data.name);
-            $('.inspect-link').click(function() { window.open("http://requestb.in/"+data.name+"?inspect"); });
+            $('.inspect-link').click(function() { window.open(binUrl + "?inspect"); });
             $('.inspect-container').slideDown();
         }
     });

--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,7 @@
 
   "permissions": [
     "cookies",
-    "http://requestb.in/"
+    "http://requestb.in/",
+    "clipboardWrite"
   ]
 }


### PR DESCRIPTION
This pull request is a continuation of #1. My changes move the copy function into a clickable icon. It's purpose is to not inadvertently override something in someone's clipboard.
